### PR TITLE
[GIT PULL] Fix build for non x86 arch

### DIFF
--- a/src/ext/Makefile
+++ b/src/ext/Makefile
@@ -16,11 +16,18 @@ include $(BASE_DIR)/src/ext/inih/Makefile
 
 ## Build HPC emerg objects
 LIB_LDFLAGS += -ldl
+
+
+UNAME_P := $(shell uname -p)
+ifeq ($(UNAME_P),x86_64)
+
 $(BASE_DIR)/src/ext/hpc_emerg/src/emerg/arch/x64/emerg.o:
 	+$(Q)$(MAKE) -s --no-print-directory -C $(BASE_DIR)/src/ext/hpc_emerg $(@)
 
 OBJ_PRE_CC += \
 	$(BASE_DIR)/src/ext/hpc_emerg/src/emerg/arch/x64/emerg.o
+
+endif
 
 hpc_emerg_clean:
 	+$(Q)$(MAKE) --no-print-directory -C $(BASE_DIR)/src/ext/hpc_emerg clean

--- a/src/ext/hpc_emerg/src/emerg/arch/Makefile
+++ b/src/ext/hpc_emerg/src/emerg/arch/Makefile
@@ -10,5 +10,37 @@
 DEP_DIRS += $(BASE_DEP_DIR)/src/emerg/arch
 
 
-# TODO: create arch detection and include specific Makefile
-include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+#
+# OS and platform detection flags
+#
+ifeq ($(OS),Windows_NT)
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+		include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+	else
+		ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+			include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+		endif
+		ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+			# include $(BASE_DIR)/src/emerg/arch/x86/Makefile
+		endif
+	endif
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		C_CXX_FLAGS += -DLINUX
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		C_CXX_FLAGS += -DOSX
+	endif
+
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),x86_64)
+		include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+	endif
+	ifneq ($(filter %86,$(UNAME_P)),)
+		# include $(BASE_DIR)/src/emerg/arch/x86/Makefile
+	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		# include $(BASE_DIR)/src/emerg/arch/arm/Makefile
+	endif
+endif

--- a/src/ext/hpc_emerg/src/emerg/arch_not_implemented.h
+++ b/src/ext/hpc_emerg/src/emerg/arch_not_implemented.h
@@ -1,0 +1,17 @@
+
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2021  Ammar Faizi <ammarfaizi2@gmail.com>
+ */
+
+#ifndef EMERG__SRC__ARCH_NOT_IMPLEMENTED_H
+#define EMERG__SRC__ARCH_NOT_IMPLEMENTED_H
+
+#define WARN()
+#define WARN_ONCE()
+#define WARN_ON(COND) ({ COND; })
+#define WARN_ON_ONCE(COND) ({ COND; })
+#define BUG()
+#define BUG_ON(COND) ({ COND; })
+
+#endif /* #ifndef EMERG__SRC__ARCH_NOT_IMPLEMENTED_H */

--- a/src/ext/hpc_emerg/src/emerg/emerg.h
+++ b/src/ext/hpc_emerg/src/emerg/emerg.h
@@ -56,11 +56,12 @@
 #  pragma clang diagnostic pop
 #endif
 
+#undef __x86_64__
 #define IN_THE_MAIN_EMERG_H
 #if defined(__x86_64__)
 #include "arch/x64/emerg.h"
 #else
-#error "Arch is not supported yet!"
+#include "arch_not_implemented.h"
 #endif
 #undef IN_THE_MAIN_EMERG_H
 

--- a/src/teavpn2/allocator.c
+++ b/src/teavpn2/allocator.c
@@ -81,7 +81,7 @@ __no_inline void *al64_realloc(void *user, size_t new_size)
 	if (unlikely(!user))
 		return al64_malloc(new_size);
 
-	memcpy(&shift, (void *)((uintptr_t)user - 1ull), sizeof(shift));
+	memcpy(&shift, (void *)((uintptr_t)user - 1ul), sizeof(shift));
 	orig = (void *)((uintptr_t)user - (uintptr_t)shift);
 
 	tmp = realloc(orig, new_size + extra_size);

--- a/src/teavpn2/main.c
+++ b/src/teavpn2/main.c
@@ -61,11 +61,13 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+#if defined(__x86_64__)
 	if (emerg_init_handler(EMERG_INIT_BUG | EMERG_INIT_WARN)) {
 		int ret = errno;
 		printf("Cannot set emerg handler: %s\n", strerror(ret));
 		return -ret;
 	}
+#endif
 
 	return run_teavpn2(argc, argv);
 }

--- a/src/teavpn2/print.c
+++ b/src/teavpn2/print.c
@@ -119,7 +119,9 @@ void __attribute__((format(printf, 3, 4)))
 __panic(const char *file, int lineno, const char *fmt, ...)
 {
 	va_list vl;
+#if defined(__x86_64__)
 	__emerg_release_bug = true;
+#endif
 	pthread_mutex_trylock(&print_lock);
 	pthread_mutex_trylock(&get_time_lock);
 	puts("=======================================================");

--- a/src/teavpn2/print.h
+++ b/src/teavpn2/print.h
@@ -54,12 +54,20 @@ static inline void set_notice_level(uint8_t level)
 #define pr_emerg	__pr_emerg
 #define pr_dbg		__pr_debug
 #define pr_warn		__pr_warn
+
+#if defined(__x86_64__)
 #define panic(...)					\
 do {							\
 	__emerg_release_bug = true;			\
 	BUG_ON(1);					\
 	__panic(__FILE__, __LINE__, __VA_ARGS__);	\
 } while (0)
+#else
+#define panic(...)					\
+do {							\
+	__panic(__FILE__, __LINE__, __VA_ARGS__);	\
+} while (0)
+#endif
 
 
 #ifdef NDEBUG


### PR DESCRIPTION
```
Hi,

Faiz Jazadi <me@lcat.dev> reported build error on Pi server (non x86-64)
machine. This pull request fixes the build.

Please review, thanks.
---
Ammar

Link: https://t.me/TeaInside/43913
Tested-by: Faiz Jazadi <me@lcat.dev>
Reported-by: Faiz Jazadi <me@lcat.dev>
Signed-off-by: Ammar Faizi <ammarfaizi2@gmail.com>
----------------------------------------------------------------
The following changes since commit 5fb1f1c48b57679ee06c226b862e013ef130be31:

  Merge branch 'dev_001' of git://github.com/ammarfaizi2/teavpn2-fork (2021-09-08 11:45:44 +0700)

are available in the Git repository at:

  git://github.com/ammarfaizi2/teavpn2-fork fix-build-non-x86-arch

for you to fetch changes up to 7b781926b54fb2e4e64dfa7fd0efd76777962673:

  panic.c: don't alter `__emerg_release_bug` on non x86-64 machine (2021-09-10 22:44:20 +0700)

----------------------------------------------------------------
Ammar Faizi (4):
      hpc_emerg: don't use hpc_emerg for unsupported arch
      src/teavpn2/allocator.c: fix pointer cast warning
      hpc_emerg: fix panic macro and emerg init call
      panic.c: don't alter `__emerg_release_bug` on non x86-64 machine

 src/ext/Makefile                                   |  7 +++++
 src/ext/hpc_emerg/src/emerg/arch/Makefile          | 36 ++++++++++++++++++++--
 src/ext/hpc_emerg/src/emerg/arch_not_implemented.h | 17 ++++++++++
 src/ext/hpc_emerg/src/emerg/emerg.h                |  3 +-
 src/teavpn2/allocator.c                            |  2 +-
 src/teavpn2/main.c                                 |  2 ++
 src/teavpn2/print.c                                |  2 ++
 src/teavpn2/print.h                                |  8 +++++
 8 files changed, 73 insertions(+), 4 deletions(-)
 create mode 100644 src/ext/hpc_emerg/src/emerg/arch_not_implemented.h

diff --git a/src/ext/Makefile b/src/ext/Makefile
index 4be54a8..187600c 100644
--- a/src/ext/Makefile
+++ b/src/ext/Makefile
@@ -16,12 +16,19 @@ include $(BASE_DIR)/src/ext/inih/Makefile
 
 ## Build HPC emerg objects
 LIB_LDFLAGS += -ldl
+
+
+UNAME_P := $(shell uname -p)
+ifeq ($(UNAME_P),x86_64)
+
 $(BASE_DIR)/src/ext/hpc_emerg/src/emerg/arch/x64/emerg.o:
 	+$(Q)$(MAKE) -s --no-print-directory -C $(BASE_DIR)/src/ext/hpc_emerg $(@)
 
 OBJ_PRE_CC += \
 	$(BASE_DIR)/src/ext/hpc_emerg/src/emerg/arch/x64/emerg.o
 
+endif
+
 hpc_emerg_clean:
 	+$(Q)$(MAKE) --no-print-directory -C $(BASE_DIR)/src/ext/hpc_emerg clean
 
diff --git a/src/ext/hpc_emerg/src/emerg/arch/Makefile b/src/ext/hpc_emerg/src/emerg/arch/Makefile
index 0c631a9..92fec31 100644
--- a/src/ext/hpc_emerg/src/emerg/arch/Makefile
+++ b/src/ext/hpc_emerg/src/emerg/arch/Makefile
@@ -10,5 +10,37 @@
 DEP_DIRS += $(BASE_DEP_DIR)/src/emerg/arch
 
 
-# TODO: create arch detection and include specific Makefile
-include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+#
+# OS and platform detection flags
+#
+ifeq ($(OS),Windows_NT)
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+		include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+	else
+		ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+			include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+		endif
+		ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+			# include $(BASE_DIR)/src/emerg/arch/x86/Makefile
+		endif
+	endif
+else
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Linux)
+		C_CXX_FLAGS += -DLINUX
+	endif
+	ifeq ($(UNAME_S),Darwin)
+		C_CXX_FLAGS += -DOSX
+	endif
+
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_P),x86_64)
+		include $(BASE_DIR)/src/emerg/arch/x64/Makefile
+	endif
+	ifneq ($(filter %86,$(UNAME_P)),)
+		# include $(BASE_DIR)/src/emerg/arch/x86/Makefile
+	endif
+	ifneq ($(filter arm%,$(UNAME_P)),)
+		# include $(BASE_DIR)/src/emerg/arch/arm/Makefile
+	endif
+endif
diff --git a/src/ext/hpc_emerg/src/emerg/arch_not_implemented.h b/src/ext/hpc_emerg/src/emerg/arch_not_implemented.h
new file mode 100644
index 0000000..3e9f5ff
--- /dev/null
+++ b/src/ext/hpc_emerg/src/emerg/arch_not_implemented.h
@@ -0,0 +1,17 @@
+
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (C) 2021  Ammar Faizi <ammarfaizi2@gmail.com>
+ */
+
+#ifndef EMERG__SRC__ARCH_NOT_IMPLEMENTED_H
+#define EMERG__SRC__ARCH_NOT_IMPLEMENTED_H
+
+#define WARN()
+#define WARN_ONCE()
+#define WARN_ON(COND) ({ COND; })
+#define WARN_ON_ONCE(COND) ({ COND; })
+#define BUG()
+#define BUG_ON(COND) ({ COND; })
+
+#endif /* #ifndef EMERG__SRC__ARCH_NOT_IMPLEMENTED_H */
diff --git a/src/ext/hpc_emerg/src/emerg/emerg.h b/src/ext/hpc_emerg/src/emerg/emerg.h
index 459df9e..9b8b725 100644
--- a/src/ext/hpc_emerg/src/emerg/emerg.h
+++ b/src/ext/hpc_emerg/src/emerg/emerg.h
@@ -56,11 +56,12 @@
 #  pragma clang diagnostic pop
 #endif
 
+#undef __x86_64__
 #define IN_THE_MAIN_EMERG_H
 #if defined(__x86_64__)
 #include "arch/x64/emerg.h"
 #else
-#error "Arch is not supported yet!"
+#include "arch_not_implemented.h"
 #endif
 #undef IN_THE_MAIN_EMERG_H
 
diff --git a/src/teavpn2/allocator.c b/src/teavpn2/allocator.c
index fdc9dad..ef4bde2 100644
--- a/src/teavpn2/allocator.c
+++ b/src/teavpn2/allocator.c
@@ -81,7 +81,7 @@ __no_inline void *al64_realloc(void *user, size_t new_size)
 	if (unlikely(!user))
 		return al64_malloc(new_size);
 
-	memcpy(&shift, (void *)((uintptr_t)user - 1ull), sizeof(shift));
+	memcpy(&shift, (void *)((uintptr_t)user - 1ul), sizeof(shift));
 	orig = (void *)((uintptr_t)user - (uintptr_t)shift);
 
 	tmp = realloc(orig, new_size + extra_size);
diff --git a/src/teavpn2/main.c b/src/teavpn2/main.c
index 3995e54..e7a183c 100644
--- a/src/teavpn2/main.c
+++ b/src/teavpn2/main.c
@@ -61,11 +61,13 @@ int main(int argc, char *argv[])
 		return 0;
 	}
 
+#if defined(__x86_64__)
 	if (emerg_init_handler(EMERG_INIT_BUG | EMERG_INIT_WARN)) {
 		int ret = errno;
 		printf("Cannot set emerg handler: %s\n", strerror(ret));
 		return -ret;
 	}
+#endif
 
 	return run_teavpn2(argc, argv);
 }
diff --git a/src/teavpn2/print.c b/src/teavpn2/print.c
index a07c4a7..ea3e7d9 100644
--- a/src/teavpn2/print.c
+++ b/src/teavpn2/print.c
@@ -119,7 +119,9 @@ void __attribute__((format(printf, 3, 4)))
 __panic(const char *file, int lineno, const char *fmt, ...)
 {
 	va_list vl;
+#if defined(__x86_64__)
 	__emerg_release_bug = true;
+#endif
 	pthread_mutex_trylock(&print_lock);
 	pthread_mutex_trylock(&get_time_lock);
 	puts("=======================================================");
diff --git a/src/teavpn2/print.h b/src/teavpn2/print.h
index 2db523f..c1215d3 100644
--- a/src/teavpn2/print.h
+++ b/src/teavpn2/print.h
@@ -54,12 +54,20 @@ static inline void set_notice_level(uint8_t level)
 #define pr_emerg	__pr_emerg
 #define pr_dbg		__pr_debug
 #define pr_warn		__pr_warn
+
+#if defined(__x86_64__)
 #define panic(...)					\
 do {							\
 	__emerg_release_bug = true;			\
 	BUG_ON(1);					\
 	__panic(__FILE__, __LINE__, __VA_ARGS__);	\
 } while (0)
+#else
+#define panic(...)					\
+do {							\
+	__panic(__FILE__, __LINE__, __VA_ARGS__);	\
+} while (0)
+#endif
 
 
 #ifdef NDEBUG
```